### PR TITLE
Use "error" status when there is a compile error

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -40,7 +40,7 @@ then
    # escape double quotes in message
    sed -i 's/"/\\"/g' error.txt
    # build json with message
-   echo '{"status": "fail", "message":"' > $OUTPUT_DIR/results.json
+   echo '{"status": "error", "message":"' > $OUTPUT_DIR/results.json
    cat error.txt >> $OUTPUT_DIR/results.json
    echo '"}' >> $OUTPUT_DIR/results.json
    # Replace line endings with \n string


### PR DESCRIPTION
When testing the Elm test runner,  I found one small issue. In the case of a compilation error, the root `"status"` field is set to `"fail"`, but instead in this case it should be set to `"error"` (see https://github.com/exercism/automated-tests/blob/master/docs/interface.md#top-level).