### PR TITLE
Automatically push Docker image to Docker Hub

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -1,0 +1,25 @@
+name: Push to DockerHub
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  dockerhub:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - uses: satackey/action-docker-layer-caching@v0.0.5
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v1.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          repository: ${{ github.event.repository.full_name }}
+          tag_with_sha: true
+          tags: latest
+          dockerfile: Dockerfile

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -1,8 +1,8 @@
 name: Push to DockerHub
 
-on: pull_request
-  # push:
-  #   branches: [master]
+on:
+  push:
+    branches: [master]
 
 jobs:
   dockerhub:

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -34,7 +34,7 @@ jobs:
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build Docker image
         id: docker_build

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -1,8 +1,8 @@
 name: Push to DockerHub
 
-on:
-  push:
-    branches: [master]
+on: pull_request
+  # push:
+  #   branches: [master]
 
 jobs:
   dockerhub:
@@ -12,14 +12,37 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - uses: satackey/action-docker-layer-caching@v0.0.5
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
 
-      - name: Build and push Docker images
-        uses: docker/build-push-action@v1.1.0
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Prepare tags
+        id: prep
+        run: |
+          REPO=${{ github.event.repository.full_name }}
+          TAGS="${REPO}:latest,${REPO}:sha-${GITHUB_SHA::8}"
+          echo ::set-output name=tags::${TAGS}
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          repository: ${{ github.event.repository.full_name }}
-          tag_with_sha: true
-          tags: latest
-          dockerfile: Dockerfile
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build Docker image
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.prep.outputs.tags }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache


### PR DESCRIPTION
The [v3 development environment](https://github.com/exercism/development-environment/) uses Docker images from Docker Hub for all the tooling.
This allows for easy testing of the various tooling components (analyzers/representer/test-runners).

This PR adds a GitHub Actions workflow to automatically build and push a new Docker image whenever something is merged to master.

See https://github.com/exercism/v3/issues/2727
