### PR TITLE
Add scripts to run all tests in exercism/elm repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ RUN cd extract-test-code \
 # Pack together things to copy to the runner container
 COPY bin/run.sh bin/run.sh
 COPY bin/smoke_test.sh bin/smoke_test.sh
+COPY bin/run_all_exercises.sh bin/run_all_exercises.sh
 
 # Lightweight runner container
 FROM node:lts-alpine

--- a/bin/run-all-exercises-in-docker.sh
+++ b/bin/run-all-exercises-in-docker.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# This script is meant to run in the exercism/elm CI
+
+set -e # Make script exit when a command fail.
+set -u # Exit on usage of undeclared variable.
+# set -x # Trace what gets executed.
+set -o pipefail # Catch failures in pipes.
+
+# Command line argument
+elm_repo_dir=$1
+
+# build docker image
+docker build --rm -t elm-test-runner .
+
+# run image passing the arguments
+docker run \
+    --rm \
+    --read-only \
+    --network none \
+    --mount type=bind,src=$(realpath $elm_repo_dir),dst=/opt/test-runner/elm_repo \
+    --mount type=tmpfs,dst=/tmp \
+    --entrypoint /opt/test-runner/bin/run_all_exercises.sh \
+    elm-test-runner \
+    /opt/test-runner/elm_repo

--- a/bin/run_all_exercises.sh
+++ b/bin/run_all_exercises.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+set -e # Make script exit when a command fail.
+set -u # Exit on usage of undeclared variable.
+# set -x # Trace what gets executed.
+set -o pipefail # Catch failures in pipes.
+
+# Command line arguments
+elm_repo=$1
+
+# Copy repo exercises into temp folder
+exercices=$(mktemp -d /tmp/exercices_XXXXXXXXXX)
+cp -r "$elm_repo/exercises/concept" "$elm_repo/exercises/practice" $exercices
+
+# Checking assumption that solution files are unique
+for config_file in "$exercices"/*/*/.meta/config.json
+do
+  solution_length=$(jq '.files.solution | length' $config_file)
+  if [[ ! $solution_length -eq 1 ]]; then
+    echo "$config_file has more than one solution"
+    exit 1
+  fi
+done
+
+# Copy exemplar files in solution
+for exercise_dir in "$exercices/concept"/*
+do
+  solution=$(jq --raw-output '.files.solution | .[0]' "$exercise_dir/.meta/config.json")
+  exemplar=$(jq --raw-output '.files.exemplar | .[0]' "$exercise_dir/.meta/config.json")
+  cp "$exercise_dir/$exemplar" "$exercise_dir/$solution"
+done
+
+# Copy example files in solution
+for exercise_dir in "$exercices/practice"/*
+do
+  solution=$(jq --raw-output '.files.solution | .[0]' "$exercise_dir/.meta/config.json")
+  example=$(jq --raw-output '.files.example | .[0]' "$exercise_dir/.meta/config.json")
+  cp "$exercise_dir/$example" "$exercise_dir/$solution"
+done
+
+# Run tests
+for exercise_dir in "$exercices"/*/*
+do
+  bin/run.sh "ignored_slug" $exercise_dir $exercise_dir > /dev/null
+  results=$(jq --raw-output '.status' "$exercise_dir/results.json")
+  if [[ $results != "pass" ]]; then
+    echo "$exercise_dir is not passing the tests"
+    exit 1
+  fi
+done
+
+echo "All exercises run in the elm-test-runner"

--- a/bin/run_all_exercises.sh
+++ b/bin/run_all_exercises.sh
@@ -23,6 +23,7 @@ do
 done
 
 # Copy exemplar files in solution
+echo "Copying concept exemplar solutions ..."
 for exercise_dir in "$exercices/concept"/*
 do
   solution=$(jq --raw-output '.files.solution | .[0]' "$exercise_dir/.meta/config.json")
@@ -31,6 +32,7 @@ do
 done
 
 # Copy example files in solution
+echo "Copying practice example solutions ..."
 for exercise_dir in "$exercices/practice"/*
 do
   solution=$(jq --raw-output '.files.solution | .[0]' "$exercise_dir/.meta/config.json")
@@ -39,6 +41,7 @@ do
 done
 
 # Run tests
+echo "Running test for all solutions ..."
 for exercise_dir in "$exercices"/*/*
 do
   bin/run.sh "ignored_slug" $exercise_dir $exercise_dir > /dev/null


### PR DESCRIPTION
With these scripts, it will be possible to run `elm-test-runner` on each exercise from the exercism/elm repo in the CI, as discussed in [this issue](https://github.com/exercism/elm/issues/412).

To test locally `bin/run-all-exercises-in-docker.sh path/to/elm/repo`.

When I try it, it's very slow and I get a bunch of "tinyproxy: Could not create listening sockets." so maybe the tinyproxy script needs to be modified, but I would like to see the behavior in the CI here before touching it.