### PR TITLE
Add parsing for `fuzz` tests family

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -40,11 +40,11 @@ set +e
 # Un-skip all the skipped tests
 sed -i 's/skip <|//g' tests/Tests.elm 2> stderr.txt
 STATUS=$?
-cat stderr.txt
+cat stderr.txt 1>&2
 if [ $STATUS -ne 0 ]; then
     jq -n --rawfile m stderr.txt '{version: 3, status: "error", message:$m}' > $OUTPUT_DIR/results.json
-    echo "An error occured while un-skipping the tests."
-    exit 0
+    echo "An error occured while un-skipping the tests." 1>&2
+    exit 1
 fi
 
 # Run the tests
@@ -54,8 +54,8 @@ cat stderr.txt
 # elm-test-rs will exit(0) if tests pass, exit(2) if tests fail
 if [ $STATUS -ne 0 ] && [ $STATUS -ne 2 ]; then
     jq -n --rawfile m stderr.txt '{version: 3, status: "error", message:$m}' > $OUTPUT_DIR/results.json
-    echo "An error occured while running the tests."
-    exit 0
+    echo "An error occured while running the tests." 1>&2
+    exit 1
 fi
 
 # Extract test code
@@ -64,8 +64,8 @@ STATUS=$?
 cat stderr.txt
 if [ $STATUS -ne 0 ]; then
     jq -n --rawfile m stderr.txt '{version: 3, status: "error", message:$m}' > $OUTPUT_DIR/results.json
-    echo "An error occurred while extracting the test code snippets."
-    exit 0
+    echo "An error occurred while extracting the test code snippets." 1>&2
+    exit 1
 fi
 
 # Check number of tests matches number of extracted code snippets
@@ -74,8 +74,8 @@ test_result_length=$(jq '.tests | length' test_results.json)
 if [ $test_code_length -ne $test_result_length ] ; then
     err="Number of tests doesn't match number of extracted code snippets. Please report this issue at https://github.com/exercism/elm-test-runner/issues."
     jq -n --arg m "${err}" '{version: 3, status: "error", message:$m}' > $OUTPUT_DIR/results.json
-    echo $err
-    exit 0
+    echo $err 1>&2
+    exit 1
 fi
 set -e
 

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -44,7 +44,7 @@ cat stderr.txt 1>&2
 if [ $STATUS -ne 0 ]; then
     jq -n --rawfile m stderr.txt '{version: 3, status: "error", message:$m}' > $OUTPUT_DIR/results.json
     echo "An error occured while un-skipping the tests." 1>&2
-    exit 1
+    exit 0
 fi
 
 # Run the tests
@@ -55,7 +55,7 @@ cat stderr.txt
 if [ $STATUS -ne 0 ] && [ $STATUS -ne 2 ]; then
     jq -n --rawfile m stderr.txt '{version: 3, status: "error", message:$m}' > $OUTPUT_DIR/results.json
     echo "An error occured while running the tests." 1>&2
-    exit 1
+    exit 0
 fi
 
 # Extract test code
@@ -65,7 +65,7 @@ cat stderr.txt
 if [ $STATUS -ne 0 ]; then
     jq -n --rawfile m stderr.txt '{version: 3, status: "error", message:$m}' > $OUTPUT_DIR/results.json
     echo "An error occurred while extracting the test code snippets." 1>&2
-    exit 1
+    exit 0
 fi
 
 # Check number of tests matches number of extracted code snippets
@@ -75,7 +75,7 @@ if [ $test_code_length -ne $test_result_length ] ; then
     err="Number of tests doesn't match number of extracted code snippets. Please report this issue at https://github.com/exercism/elm-test-runner/issues."
     jq -n --arg m "${err}" '{version: 3, status: "error", message:$m}' > $OUTPUT_DIR/results.json
     echo $err 1>&2
-    exit 1
+    exit 0
 fi
 set -e
 

--- a/bin/smoke_test.sh
+++ b/bin/smoke_test.sh
@@ -14,19 +14,19 @@ for solution in test_data/*/* ; do
 
   # check result
   if [[ ! -f "${solution}/expected_results.json" ]]; then
-    echo "🔥 ${solution}: expected expected_results.json to exist 🔥"
+    echo "🔥 ${solution}: expected expected_results.json to exist 🔥" 1>&2
     exit 1
   fi
 
   if [[ ! -f "${solution}/results.json" ]]; then
-    echo "🔥 ${solution}: expected results.json to exist on successful run 🔥"
+    echo "🔥 ${solution}: expected results.json to exist on successful run 🔥" 1>&2
     exit 1
   fi
 
   jq -S . ${solution}/expected_results.json > /tmp/expected.json
   jq -S . ${solution}/results.json > /tmp/actual.json
   if ! diff /tmp/expected.json /tmp/actual.json ;then
-    echo "🔥 ${solution}: expected results.json to equal expected_results.json on successful run 🔥"
+    echo "🔥 ${solution}: expected results.json to equal expected_results.json on successful run 🔥" 1>&2
     exit 1
   fi
 

--- a/extract-test-code/src/ExtractTestCode.elm
+++ b/extract-test-code/src/ExtractTestCode.elm
@@ -4,6 +4,7 @@ import Elm.Parser
 import Elm.Processing exposing (init, process)
 import Elm.Syntax.Declaration as Declaration exposing (Declaration)
 import Elm.Syntax.Expression exposing (..)
+import Elm.Syntax.Infix exposing (InfixDirection(..))
 import Elm.Syntax.Node as Node
 import Elm.Syntax.Range exposing (emptyRange)
 import Elm.Writer exposing (writeExpression)
@@ -207,18 +208,32 @@ are necessary to understand the test
 -}
 extractFromFuzzFunction : List String -> List Expression -> Expression -> List ( String, Expression )
 extractFromFuzzFunction descriptions expressions topExpression =
+    let
+        finalExpression =
+            case topExpression of
+                Application nodeExpressions ->
+                    case nodeExpressions |> List.reverse of
+                        lambda :: rest ->
+                            Application (List.reverse (Node.Node emptyRange (ParenthesizedExpression lambda) :: rest))
+
+                        _ ->
+                            topExpression
+
+                _ ->
+                    topExpression
+    in
     case expressions of
         [ FunctionOrValue _ "fuzz", _, Literal name, _ ] ->
-            [ ( buildName name descriptions, topExpression ) ]
+            [ ( buildName name descriptions, finalExpression ) ]
 
         [ FunctionOrValue _ "fuzz2", _, _, Literal name, _ ] ->
-            [ ( buildName name descriptions, topExpression ) ]
+            [ ( buildName name descriptions, finalExpression ) ]
 
         [ FunctionOrValue _ "fuzz3", _, _, _, Literal name, _ ] ->
-            [ ( buildName name descriptions, topExpression ) ]
+            [ ( buildName name descriptions, finalExpression ) ]
 
         [ FunctionOrValue _ "fuzzWith", _, _, Literal name, _ ] ->
-            [ ( buildName name descriptions, topExpression ) ]
+            [ ( buildName name descriptions, finalExpression ) ]
 
         _ ->
             []

--- a/extract-test-code/tests/FuzzTest.elm
+++ b/extract-test-code/tests/FuzzTest.elm
@@ -42,13 +42,13 @@ tests =
                                   , testCode =
                                         """fuzz Fuzz.int
  "modifier is always smaller than score"
- \\score -> Expect.atMost score (DndCharacter.modifier score)"""
+ (\\score -> Expect.atMost score (DndCharacter.modifier score))"""
                                   }
                                 , { name = "ability > generated ability should be at least 3"
                                   , testCode =
                                         """fuzz (Fuzz.fromGenerator DndCharacter.ability)
  "generated ability should be at least 3"
- \\ability -> Expect.atLeast 3 ability"""
+ (\\ability -> Expect.atLeast 3 ability)"""
                                   }
                                 ]
                             )
@@ -88,14 +88,14 @@ tests =
                                         """fuzz2 Fuzz.int
  Fuzz.int
  "two scores can have the same modifier"
- \\a b -> (div a / 2 != div b / 2) || modifier a == modifier b"""
+ (\\a b -> (div a / 2 != div b / 2) || modifier a == modifier b)"""
                                   }
                                 , { name = "ability > abilities are never more than 15 apart"
                                   , testCode =
                                         """fuzz2 (Fuzz.fromGenerator DndCharacter.ability)
  (Fuzz.fromGenerator DndCharacter.ability)
  "abilities are never more than 15 apart"
- \\a b -> Expect.atMost 15 (abs (a - b))"""
+ (\\a b -> Expect.atMost 15 (abs (a - b)))"""
                                   }
                                 ]
                             )
@@ -137,7 +137,7 @@ tests =
  Fuzz.int
  Fuzz.int
  "three scores can have the same modifier"
- \\a b c -> (div a / 2 != div b / 2) || modifier a == modifier b"""
+ (\\a b c -> (div a / 2 != div b / 2) || modifier a == modifier b)"""
                                   }
                                 , { name = "ability > abilities are never more than 15 apart"
                                   , testCode =
@@ -145,7 +145,7 @@ tests =
  (Fuzz.fromGenerator DndCharacter.ability)
  (Fuzz.fromGenerator DndCharacter.ability)
  "abilities are never more than 15 apart"
- \\a b c -> Expect.atMost 15 (abs (a - c))"""
+ (\\a b c -> Expect.atMost 15 (abs (a - c)))"""
                                   }
                                 ]
                             )
@@ -194,7 +194,7 @@ tests =
                                         """fuzzWith {runs = 10000, distribution = Test.NoDistribution}
  Fuzz.int
  "modifier is always smaller than score"
- \\score -> Expect.atMost score (DndCharacter.modifier score)"""
+ (\\score -> Expect.atMost score (DndCharacter.modifier score))"""
                                   }
                                 , { name = "ability > 13 has an approximate 13% chance of being picked"
                                   , testCode =
@@ -203,7 +203,7 @@ tests =
 , (Test.Distribution.atLeast 85, "is not 13", (/=) 13)]}
  (Fuzz.fromGenerator DndCharacter.ability)
  "13 has an approximate 13% chance of being picked"
- \\_ -> Expect.pass"""
+ (\\_ -> Expect.pass)"""
                                   }
                                 ]
                             )

--- a/extract-test-code/tests/FuzzTest.elm
+++ b/extract-test-code/tests/FuzzTest.elm
@@ -1,0 +1,211 @@
+module FuzzTest exposing (..)
+
+import Expect
+import ExtractTestCode
+import Json.Encode
+import Test exposing (..)
+
+
+tests : Test
+tests =
+    describe "Can extract tests written with the fuzz family"
+        [ test "Can extract a test written with fuzz" <|
+            \_ ->
+                """module Tests exposing (tests)
+
+import DndCharacter
+import Expect
+import Fuzz
+import Test exposing (Test, describe, fuzzWith, skip, test)
+
+
+tests : Test
+tests =
+    describe "DndCharacter"
+        [ describe "modifier"
+            [ fuzz Fuzz.int "modifier is always smaller than score" <|
+                \\score -> Expect.atMost score (DndCharacter.modifier score)
+            ]
+        , describe "ability"
+            [ fuzz (Fuzz.fromGenerator DndCharacter.ability)
+                "generated ability should be at least 3"
+              <|
+                \\ability -> Expect.atLeast 3 ability
+            ]
+        ]
+"""
+                    |> ExtractTestCode.extractTestCode
+                    |> Expect.equal
+                        (Json.Encode.encode 2
+                            (Json.Encode.list ExtractTestCode.encode
+                                [ { name = "modifier > modifier is always smaller than score"
+                                  , testCode =
+                                        """fuzz Fuzz.int
+ "modifier is always smaller than score"
+ \\score -> Expect.atMost score (DndCharacter.modifier score)"""
+                                  }
+                                , { name = "ability > generated ability should be at least 3"
+                                  , testCode =
+                                        """fuzz (Fuzz.fromGenerator DndCharacter.ability)
+ "generated ability should be at least 3"
+ \\ability -> Expect.atLeast 3 ability"""
+                                  }
+                                ]
+                            )
+                        )
+        , test "Can extract a test written with fuzz2" <|
+            \_ ->
+                """module Tests exposing (tests)
+
+import DndCharacter
+import Expect
+import Fuzz
+import Test exposing (Test, describe, fuzzWith, skip, test)
+
+
+tests : Test
+tests =
+    describe "DndCharacter"
+        [ describe "modifier"
+            [ fuzz2 Fuzz.int Fuzz.int "two scores can have the same modifier" <|
+                \\a b -> (div a / 2 != div b / 2) || modifier a == modifier b
+            ]
+        , describe "ability"
+            [ fuzz2 (Fuzz.fromGenerator DndCharacter.ability)
+                (Fuzz.fromGenerator DndCharacter.ability)
+                "abilities are never more than 15 apart"
+              <|
+                \\a b -> Expect.atMost 15 (abs (a - b))
+            ]
+        ]
+"""
+                    |> ExtractTestCode.extractTestCode
+                    |> Expect.equal
+                        (Json.Encode.encode 2
+                            (Json.Encode.list ExtractTestCode.encode
+                                [ { name = "modifier > two scores can have the same modifier"
+                                  , testCode =
+                                        """fuzz2 Fuzz.int
+ Fuzz.int
+ "two scores can have the same modifier"
+ \\a b -> (div a / 2 != div b / 2) || modifier a == modifier b"""
+                                  }
+                                , { name = "ability > abilities are never more than 15 apart"
+                                  , testCode =
+                                        """fuzz2 (Fuzz.fromGenerator DndCharacter.ability)
+ (Fuzz.fromGenerator DndCharacter.ability)
+ "abilities are never more than 15 apart"
+ \\a b -> Expect.atMost 15 (abs (a - b))"""
+                                  }
+                                ]
+                            )
+                        )
+        , test "Can extract a test written with fuzz3" <|
+            \_ ->
+                """module Tests exposing (tests)
+
+import DndCharacter
+import Expect
+import Fuzz
+import Test exposing (Test, describe, fuzzWith, skip, test)
+
+
+tests : Test
+tests =
+    describe "DndCharacter"
+        [ describe "modifier"
+            [ fuzz3 Fuzz.int Fuzz.int Fuzz.int "three scores can have the same modifier" <|
+                \\a b c-> (div a / 2 != div b / 2) || modifier a == modifier b
+            ]
+        , describe "ability"
+            [ fuzz3 (Fuzz.fromGenerator DndCharacter.ability)
+                (Fuzz.fromGenerator DndCharacter.ability)
+                (Fuzz.fromGenerator DndCharacter.ability)
+                "abilities are never more than 15 apart"
+              <|
+                \\a b c -> Expect.atMost 15 (abs (a - c))
+            ]
+        ]
+"""
+                    |> ExtractTestCode.extractTestCode
+                    |> Expect.equal
+                        (Json.Encode.encode 2
+                            (Json.Encode.list ExtractTestCode.encode
+                                [ { name = "modifier > three scores can have the same modifier"
+                                  , testCode =
+                                        """fuzz3 Fuzz.int
+ Fuzz.int
+ Fuzz.int
+ "three scores can have the same modifier"
+ \\a b c -> (div a / 2 != div b / 2) || modifier a == modifier b"""
+                                  }
+                                , { name = "ability > abilities are never more than 15 apart"
+                                  , testCode =
+                                        """fuzz3 (Fuzz.fromGenerator DndCharacter.ability)
+ (Fuzz.fromGenerator DndCharacter.ability)
+ (Fuzz.fromGenerator DndCharacter.ability)
+ "abilities are never more than 15 apart"
+ \\a b c -> Expect.atMost 15 (abs (a - c))"""
+                                  }
+                                ]
+                            )
+                        )
+        , test "Can extract a test written with fuzzWith" <|
+            \_ ->
+                """module Tests exposing (tests)
+
+import DndCharacter
+import Expect
+import Fuzz
+import Test exposing (Test, describe, fuzzWith, skip, test)
+
+
+tests : Test
+tests =
+    describe "DndCharacter"
+        [ describe "modifier"
+            [ fuzzWith
+                { runs = 10000, distribution = Test.NoDistribution }
+                Fuzz.int "modifier is always smaller than score" <|
+                \\score -> Expect.atMost score (DndCharacter.modifier score)
+            ]
+        , describe "ability"
+            [ fuzzWith
+                { runs = 10000
+                , distribution =
+                    Test.expectDistribution
+                        [ ( Test.Distribution.atLeast 10, "is 13", (==) 13 )
+                        , ( Test.Distribution.atLeast 85, "is not 13", (/=) 13 )
+                        ]
+                }
+                (Fuzz.fromGenerator DndCharacter.ability)
+                "13 has an approximate 13% chance of being picked"
+            <|
+                \\_ -> Expect.pass
+            ]
+        ]
+"""
+                    |> ExtractTestCode.extractTestCode
+                    |> Expect.equal
+                        (Json.Encode.encode 2
+                            (Json.Encode.list ExtractTestCode.encode
+                                [ { name = "modifier > modifier is always smaller than score"
+                                  , testCode =
+                                        """fuzzWith {runs = 10000, distribution = Test.NoDistribution}
+ Fuzz.int
+ "modifier is always smaller than score"
+ \\score -> Expect.atMost score (DndCharacter.modifier score)"""
+                                  }
+                                , { name = "ability > 13 has an approximate 13% chance of being picked"
+                                  , testCode =
+                                        """fuzzWith {runs = 10000
+, distribution = Test.expectDistribution [(Test.Distribution.atLeast 10, "is 13", (==) 13)
+, (Test.Distribution.atLeast 85, "is not 13", (/=) 13)]}
+ (Fuzz.fromGenerator DndCharacter.ability)
+ "13 has an approximate 13% chance of being picked"
+ \\_ -> Expect.pass"""
+                                  }
+                                ]
+                            )
+                        )
+        ]

--- a/test_data/dnd-character/partial_fail/elm.json
+++ b/test_data/dnd-character/partial_fail/elm.json
@@ -1,0 +1,29 @@
+{
+    "type": "application",
+    "source-directories": [
+        "src"
+    ],
+    "elm-version": "0.19.1",
+    "dependencies": {
+        "direct": {
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
+        },
+        "indirect": {}
+    },
+    "test-dependencies": {
+        "direct": {
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
+        },
+        "indirect": {
+            "elm/bytes": "1.0.8",
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.3"
+        }
+    }
+}

--- a/test_data/dnd-character/partial_fail/expected_results.json
+++ b/test_data/dnd-character/partial_fail/expected_results.json
@@ -1,0 +1,118 @@
+{
+  "version": 3,
+  "status": "fail",
+  "tests": [
+    {
+      "name": "ability > generated ability should be at least 3",
+      "task_id": null,
+      "status": "pass",
+      "message": null,
+      "output": null,
+      "test_code": "fuzzWith {runs = 1000, distribution = Test.noDistribution}\n (Fuzz.fromGenerator DndCharacter.ability)\n \"generated ability should be at least 3\"\n \\ability -> Expect.atLeast 3 ability"
+    },
+    {
+      "name": "ability > generated ability should be at most 18",
+      "task_id": null,
+      "status": "fail",
+      "message": "\nGiven 45\n\n    45\n    ╷\n    │ Expect.atMost\n    ╵\n    18\n\n",
+      "output": null,
+      "test_code": "fuzzWith {runs = 1000, distribution = Test.noDistribution}\n (Fuzz.fromGenerator DndCharacter.ability)\n \"generated ability should be at most 18\"\n \\ability -> Expect.atMost 18 ability"
+    },
+    {
+      "name": "ability > generated ability should sometimes be 3",
+      "task_id": null,
+      "status": "fail",
+      "message": "\n    Distribution of label \"is 3\" was insufficient:\n      expected:  more than 0%\n      got:       0.000%.\n    \n    (Generated 10000 values.)\n\n",
+      "output": null,
+      "test_code": "fuzzWith {runs = 10000\n, distribution = Test.expectDistribution [(Test.Distribution.moreThanZero, \"is 3\", (==) 3)]}\n (Fuzz.fromGenerator DndCharacter.ability)\n \"generated ability should sometimes be 3\"\n \\_ -> Expect.pass"
+    },
+    {
+      "name": "ability > generated ability should sometimes be 18",
+      "task_id": null,
+      "status": "fail",
+      "message": "\n    Distribution of label \"is 18\" was insufficient:\n      expected:  more than 0%\n      got:       0.000%.\n    \n    (Generated 1000 values.)\n\n",
+      "output": null,
+      "test_code": "fuzzWith {runs = 1000\n, distribution = Test.expectDistribution [(Test.Distribution.moreThanZero, \"is 18\", (==) 18)]}\n (Fuzz.fromGenerator DndCharacter.ability)\n \"generated ability should sometimes be 18\"\n \\_ -> Expect.pass"
+    },
+    {
+      "name": "ability > 13 has an approximate 13% chance of being picked",
+      "task_id": null,
+      "status": "fail",
+      "message": "\n    Distribution of label \"is 13\" was insufficient:\n      expected:  10.000%\n      got:       0.000%.\n    \n    (Generated 10000 values.)\n\n",
+      "output": null,
+      "test_code": "fuzzWith {runs = 10000\n, distribution = Test.expectDistribution [(Test.Distribution.atLeast 10, \"is 13\", (==) 13)\n, (Test.Distribution.atLeast 85, \"is not 13\", (/=) 13)]}\n (Fuzz.fromGenerator DndCharacter.ability)\n \"13 has an approximate 13% chance of being picked\"\n \\_ -> Expect.pass"
+    },
+    {
+      "name": "character > generated character strength should be within range",
+      "task_id": null,
+      "status": "fail",
+      "message": "\nGiven { charisma = 1, constitution = 1, dexterity = 1, hitpoints = 1, intelligence = 1, strength = 1, wisdom = 1 }\n\n    1\n    ╷\n    │ Expect.atLeast\n    ╵\n    3\n\n",
+      "output": null,
+      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character strength should be within range\"\n \\character -> Expect.all [Expect.atLeast 3, Expect.atMost 18] character.strength"
+    },
+    {
+      "name": "character > generated character dexterity should be within range",
+      "task_id": null,
+      "status": "fail",
+      "message": "\nGiven { charisma = 1, constitution = 1, dexterity = 1, hitpoints = 1, intelligence = 1, strength = 1, wisdom = 1 }\n\n    1\n    ╷\n    │ Expect.atLeast\n    ╵\n    3\n\n",
+      "output": null,
+      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character dexterity should be within range\"\n \\character -> Expect.all [Expect.atLeast 3, Expect.atMost 18] character.dexterity"
+    },
+    {
+      "name": "character > generated character constitution should be within range",
+      "task_id": null,
+      "status": "fail",
+      "message": "\nGiven { charisma = 1, constitution = 1, dexterity = 1, hitpoints = 1, intelligence = 1, strength = 1, wisdom = 1 }\n\n    1\n    ╷\n    │ Expect.atLeast\n    ╵\n    3\n\n",
+      "output": null,
+      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character constitution should be within range\"\n \\character -> Expect.all [Expect.atLeast 3, Expect.atMost 18] character.constitution"
+    },
+    {
+      "name": "character > generated character intelligence should be within range",
+      "task_id": null,
+      "status": "fail",
+      "message": "\nGiven { charisma = 1, constitution = 1, dexterity = 1, hitpoints = 1, intelligence = 1, strength = 1, wisdom = 1 }\n\n    1\n    ╷\n    │ Expect.atLeast\n    ╵\n    3\n\n",
+      "output": null,
+      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character intelligence should be within range\"\n \\character -> Expect.all [Expect.atLeast 3, Expect.atMost 18] character.intelligence"
+    },
+    {
+      "name": "character > generated character wisdom should be within range",
+      "task_id": null,
+      "status": "fail",
+      "message": "\nGiven { charisma = 1, constitution = 1, dexterity = 1, hitpoints = 1, intelligence = 1, strength = 1, wisdom = 1 }\n\n    1\n    ╷\n    │ Expect.atLeast\n    ╵\n    3\n\n",
+      "output": null,
+      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character wisdom should be within range\"\n \\character -> Expect.all [Expect.atLeast 3, Expect.atMost 18] character.wisdom"
+    },
+    {
+      "name": "character > generated character charisma should be within range",
+      "task_id": null,
+      "status": "fail",
+      "message": "\nGiven { charisma = 1, constitution = 1, dexterity = 1, hitpoints = 1, intelligence = 1, strength = 1, wisdom = 1 }\n\n    1\n    ╷\n    │ Expect.atLeast\n    ╵\n    3\n\n",
+      "output": null,
+      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character charisma should be within range\"\n \\character -> Expect.all [Expect.atLeast 3, Expect.atMost 18] character.charisma"
+    },
+    {
+      "name": "character > generated character hitpoints should be 10 plus the constitution modifier",
+      "task_id": null,
+      "status": "fail",
+      "message": "\nGiven { charisma = 1, constitution = 1, dexterity = 1, hitpoints = 1, intelligence = 1, strength = 1, wisdom = 1 }\n\n    5\n    ╷\n    │ Expect.equal\n    ╵\n    1\n\n",
+      "output": null,
+      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character hitpoints should be 10 plus the constitution modifier\"\n \\character -> Expect.equal character.hitpoints (10 + DndCharacter.modifier character.constitution)"
+    },
+    {
+      "name": "character > generated character abilities are not all equal",
+      "task_id": null,
+      "status": "fail",
+      "message": "\nGiven { charisma = 1, constitution = 1, dexterity = 1, hitpoints = 1, intelligence = 1, strength = 1, wisdom = 1 }\n\n    1\n    ╷\n    │ Expect.atLeast\n    ╵\n    2\n\n",
+      "output": null,
+      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character abilities are not all equal\"\n \\character -> let\n  \n  \n  uniqueAbilities {strength, dexterity, constitution, intelligence, wisdom, charisma} =\n      [strength, dexterity, constitution, intelligence, wisdom, charisma] |> Set.fromList |> Set.size\nin\n  Expect.atLeast 2 (uniqueAbilities character)"
+    },
+    {
+      "name": "character > generated characters are not all equal",
+      "task_id": null,
+      "status": "fail",
+      "message": "\n    Distribution of label \"has high charisma\" was insufficient:\n      expected:  40.000%\n      got:       0.000%.\n    \n    (Generated 1000 values.)\n\n",
+      "output": null,
+      "test_code": "fuzzWith {runs = 1000\n, distribution = Test.expectDistribution [(Test.Distribution.atLeast 40, \"has low charisma\", \\char -> char.charisma <= 12)\n, (Test.Distribution.atLeast 40, \"has high charisma\", \\char -> char.charisma > 12)\n, (Test.Distribution.atLeast 40, \"has low strength\", \\char -> char.strength <= 12)\n, (Test.Distribution.atLeast 40, \"has high strength\", \\char -> char.strength > 12)]}\n (Fuzz.fromGenerator DndCharacter.character)\n \"generated characters are not all equal\"\n \\_ -> Expect.pass"
+    }
+  ]
+}

--- a/test_data/dnd-character/partial_fail/expected_results.json
+++ b/test_data/dnd-character/partial_fail/expected_results.json
@@ -8,7 +8,7 @@
       "status": "pass",
       "message": null,
       "output": null,
-      "test_code": "fuzzWith {runs = 1000, distribution = Test.noDistribution}\n (Fuzz.fromGenerator DndCharacter.ability)\n \"generated ability should be at least 3\"\n \\ability -> Expect.atLeast 3 ability"
+      "test_code": "fuzzWith {runs = 1000, distribution = Test.noDistribution}\n (Fuzz.fromGenerator DndCharacter.ability)\n \"generated ability should be at least 3\"\n (\\ability -> Expect.atLeast 3 ability)"
     },
     {
       "name": "ability > generated ability should be at most 18",
@@ -16,7 +16,7 @@
       "status": "fail",
       "message": "\nGiven 45\n\n    45\n    ╷\n    │ Expect.atMost\n    ╵\n    18\n\n",
       "output": null,
-      "test_code": "fuzzWith {runs = 1000, distribution = Test.noDistribution}\n (Fuzz.fromGenerator DndCharacter.ability)\n \"generated ability should be at most 18\"\n \\ability -> Expect.atMost 18 ability"
+      "test_code": "fuzzWith {runs = 1000, distribution = Test.noDistribution}\n (Fuzz.fromGenerator DndCharacter.ability)\n \"generated ability should be at most 18\"\n (\\ability -> Expect.atMost 18 ability)"
     },
     {
       "name": "ability > generated ability should sometimes be 3",
@@ -24,7 +24,7 @@
       "status": "fail",
       "message": "\n    Distribution of label \"is 3\" was insufficient:\n      expected:  more than 0%\n      got:       0.000%.\n    \n    (Generated 10000 values.)\n\n",
       "output": null,
-      "test_code": "fuzzWith {runs = 10000\n, distribution = Test.expectDistribution [(Test.Distribution.moreThanZero, \"is 3\", (==) 3)]}\n (Fuzz.fromGenerator DndCharacter.ability)\n \"generated ability should sometimes be 3\"\n \\_ -> Expect.pass"
+      "test_code": "fuzzWith {runs = 10000\n, distribution = Test.expectDistribution [(Test.Distribution.moreThanZero, \"is 3\", (==) 3)]}\n (Fuzz.fromGenerator DndCharacter.ability)\n \"generated ability should sometimes be 3\"\n (\\_ -> Expect.pass)"
     },
     {
       "name": "ability > generated ability should sometimes be 18",
@@ -32,7 +32,7 @@
       "status": "fail",
       "message": "\n    Distribution of label \"is 18\" was insufficient:\n      expected:  more than 0%\n      got:       0.000%.\n    \n    (Generated 1000 values.)\n\n",
       "output": null,
-      "test_code": "fuzzWith {runs = 1000\n, distribution = Test.expectDistribution [(Test.Distribution.moreThanZero, \"is 18\", (==) 18)]}\n (Fuzz.fromGenerator DndCharacter.ability)\n \"generated ability should sometimes be 18\"\n \\_ -> Expect.pass"
+      "test_code": "fuzzWith {runs = 1000\n, distribution = Test.expectDistribution [(Test.Distribution.moreThanZero, \"is 18\", (==) 18)]}\n (Fuzz.fromGenerator DndCharacter.ability)\n \"generated ability should sometimes be 18\"\n (\\_ -> Expect.pass)"
     },
     {
       "name": "ability > 13 has an approximate 13% chance of being picked",
@@ -40,7 +40,7 @@
       "status": "fail",
       "message": "\n    Distribution of label \"is 13\" was insufficient:\n      expected:  10.000%\n      got:       0.000%.\n    \n    (Generated 10000 values.)\n\n",
       "output": null,
-      "test_code": "fuzzWith {runs = 10000\n, distribution = Test.expectDistribution [(Test.Distribution.atLeast 10, \"is 13\", (==) 13)\n, (Test.Distribution.atLeast 85, \"is not 13\", (/=) 13)]}\n (Fuzz.fromGenerator DndCharacter.ability)\n \"13 has an approximate 13% chance of being picked\"\n \\_ -> Expect.pass"
+      "test_code": "fuzzWith {runs = 10000\n, distribution = Test.expectDistribution [(Test.Distribution.atLeast 10, \"is 13\", (==) 13)\n, (Test.Distribution.atLeast 85, \"is not 13\", (/=) 13)]}\n (Fuzz.fromGenerator DndCharacter.ability)\n \"13 has an approximate 13% chance of being picked\"\n (\\_ -> Expect.pass)"
     },
     {
       "name": "character > generated character strength should be within range",
@@ -48,7 +48,7 @@
       "status": "fail",
       "message": "\nGiven { charisma = 1, constitution = 1, dexterity = 1, hitpoints = 1, intelligence = 1, strength = 1, wisdom = 1 }\n\n    1\n    ╷\n    │ Expect.atLeast\n    ╵\n    3\n\n",
       "output": null,
-      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character strength should be within range\"\n \\character -> Expect.all [Expect.atLeast 3, Expect.atMost 18] character.strength"
+      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character strength should be within range\"\n (\\character -> Expect.all [Expect.atLeast 3, Expect.atMost 18] character.strength)"
     },
     {
       "name": "character > generated character dexterity should be within range",
@@ -56,7 +56,7 @@
       "status": "fail",
       "message": "\nGiven { charisma = 1, constitution = 1, dexterity = 1, hitpoints = 1, intelligence = 1, strength = 1, wisdom = 1 }\n\n    1\n    ╷\n    │ Expect.atLeast\n    ╵\n    3\n\n",
       "output": null,
-      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character dexterity should be within range\"\n \\character -> Expect.all [Expect.atLeast 3, Expect.atMost 18] character.dexterity"
+      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character dexterity should be within range\"\n (\\character -> Expect.all [Expect.atLeast 3, Expect.atMost 18] character.dexterity)"
     },
     {
       "name": "character > generated character constitution should be within range",
@@ -64,7 +64,7 @@
       "status": "fail",
       "message": "\nGiven { charisma = 1, constitution = 1, dexterity = 1, hitpoints = 1, intelligence = 1, strength = 1, wisdom = 1 }\n\n    1\n    ╷\n    │ Expect.atLeast\n    ╵\n    3\n\n",
       "output": null,
-      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character constitution should be within range\"\n \\character -> Expect.all [Expect.atLeast 3, Expect.atMost 18] character.constitution"
+      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character constitution should be within range\"\n (\\character -> Expect.all [Expect.atLeast 3, Expect.atMost 18] character.constitution)"
     },
     {
       "name": "character > generated character intelligence should be within range",
@@ -72,7 +72,7 @@
       "status": "fail",
       "message": "\nGiven { charisma = 1, constitution = 1, dexterity = 1, hitpoints = 1, intelligence = 1, strength = 1, wisdom = 1 }\n\n    1\n    ╷\n    │ Expect.atLeast\n    ╵\n    3\n\n",
       "output": null,
-      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character intelligence should be within range\"\n \\character -> Expect.all [Expect.atLeast 3, Expect.atMost 18] character.intelligence"
+      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character intelligence should be within range\"\n (\\character -> Expect.all [Expect.atLeast 3, Expect.atMost 18] character.intelligence)"
     },
     {
       "name": "character > generated character wisdom should be within range",
@@ -80,7 +80,7 @@
       "status": "fail",
       "message": "\nGiven { charisma = 1, constitution = 1, dexterity = 1, hitpoints = 1, intelligence = 1, strength = 1, wisdom = 1 }\n\n    1\n    ╷\n    │ Expect.atLeast\n    ╵\n    3\n\n",
       "output": null,
-      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character wisdom should be within range\"\n \\character -> Expect.all [Expect.atLeast 3, Expect.atMost 18] character.wisdom"
+      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character wisdom should be within range\"\n (\\character -> Expect.all [Expect.atLeast 3, Expect.atMost 18] character.wisdom)"
     },
     {
       "name": "character > generated character charisma should be within range",
@@ -88,7 +88,7 @@
       "status": "fail",
       "message": "\nGiven { charisma = 1, constitution = 1, dexterity = 1, hitpoints = 1, intelligence = 1, strength = 1, wisdom = 1 }\n\n    1\n    ╷\n    │ Expect.atLeast\n    ╵\n    3\n\n",
       "output": null,
-      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character charisma should be within range\"\n \\character -> Expect.all [Expect.atLeast 3, Expect.atMost 18] character.charisma"
+      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character charisma should be within range\"\n (\\character -> Expect.all [Expect.atLeast 3, Expect.atMost 18] character.charisma)"
     },
     {
       "name": "character > generated character hitpoints should be 10 plus the constitution modifier",
@@ -96,7 +96,7 @@
       "status": "fail",
       "message": "\nGiven { charisma = 1, constitution = 1, dexterity = 1, hitpoints = 1, intelligence = 1, strength = 1, wisdom = 1 }\n\n    5\n    ╷\n    │ Expect.equal\n    ╵\n    1\n\n",
       "output": null,
-      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character hitpoints should be 10 plus the constitution modifier\"\n \\character -> Expect.equal character.hitpoints (10 + DndCharacter.modifier character.constitution)"
+      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character hitpoints should be 10 plus the constitution modifier\"\n (\\character -> Expect.equal character.hitpoints (10 + DndCharacter.modifier character.constitution))"
     },
     {
       "name": "character > generated character abilities are not all equal",
@@ -104,7 +104,7 @@
       "status": "fail",
       "message": "\nGiven { charisma = 1, constitution = 1, dexterity = 1, hitpoints = 1, intelligence = 1, strength = 1, wisdom = 1 }\n\n    1\n    ╷\n    │ Expect.atLeast\n    ╵\n    2\n\n",
       "output": null,
-      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character abilities are not all equal\"\n \\character -> let\n  \n  \n  uniqueAbilities {strength, dexterity, constitution, intelligence, wisdom, charisma} =\n      [strength, dexterity, constitution, intelligence, wisdom, charisma] |> Set.fromList |> Set.size\nin\n  Expect.atLeast 2 (uniqueAbilities character)"
+      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character abilities are not all equal\"\n (\\character -> let\n  \n  \n  uniqueAbilities {strength, dexterity, constitution, intelligence, wisdom, charisma} =\n      [strength, dexterity, constitution, intelligence, wisdom, charisma] |> Set.fromList |> Set.size\nin\n  Expect.atLeast 2 (uniqueAbilities character))"
     },
     {
       "name": "character > generated characters are not all equal",
@@ -112,7 +112,7 @@
       "status": "fail",
       "message": "\n    Distribution of label \"has high charisma\" was insufficient:\n      expected:  40.000%\n      got:       0.000%.\n    \n    (Generated 1000 values.)\n\n",
       "output": null,
-      "test_code": "fuzzWith {runs = 1000\n, distribution = Test.expectDistribution [(Test.Distribution.atLeast 40, \"has low charisma\", \\char -> char.charisma <= 12)\n, (Test.Distribution.atLeast 40, \"has high charisma\", \\char -> char.charisma > 12)\n, (Test.Distribution.atLeast 40, \"has low strength\", \\char -> char.strength <= 12)\n, (Test.Distribution.atLeast 40, \"has high strength\", \\char -> char.strength > 12)]}\n (Fuzz.fromGenerator DndCharacter.character)\n \"generated characters are not all equal\"\n \\_ -> Expect.pass"
+      "test_code": "fuzzWith {runs = 1000\n, distribution = Test.expectDistribution [(Test.Distribution.atLeast 40, \"has low charisma\", \\char -> char.charisma <= 12)\n, (Test.Distribution.atLeast 40, \"has high charisma\", \\char -> char.charisma > 12)\n, (Test.Distribution.atLeast 40, \"has low strength\", \\char -> char.strength <= 12)\n, (Test.Distribution.atLeast 40, \"has high strength\", \\char -> char.strength > 12)]}\n (Fuzz.fromGenerator DndCharacter.character)\n \"generated characters are not all equal\"\n (\\_ -> Expect.pass)"
     }
   ]
 }

--- a/test_data/dnd-character/partial_fail/src/DndCharacter.elm
+++ b/test_data/dnd-character/partial_fail/src/DndCharacter.elm
@@ -1,0 +1,34 @@
+module DndCharacter exposing (Character, ability, character, modifier)
+
+import Random exposing (Generator)
+
+
+type alias Character =
+    { strength : Int
+    , dexterity : Int
+    , constitution : Int
+    , intelligence : Int
+    , wisdom : Int
+    , charisma : Int
+    , hitpoints : Int
+    }
+
+
+modifier : Int -> Int
+modifier score =
+    floor ((toFloat score - 10) / 2)
+
+
+ability : Generator Int
+ability =
+    let
+        sumOfMaxThree =
+            List.sort >> List.reverse >> List.take 3 >> List.sum
+    in
+    Random.list 4 (Random.int 10 16)
+        |> Random.map sumOfMaxThree
+
+
+character : Generator Character
+character =
+    Random.constant (Character 1 1 1 1 1 1 1)

--- a/test_data/dnd-character/partial_fail/tests/Tests.elm
+++ b/test_data/dnd-character/partial_fail/tests/Tests.elm
@@ -1,0 +1,134 @@
+module Tests exposing (tests)
+
+import DndCharacter
+import Expect
+import Fuzz
+import Set
+import Test exposing (Test, describe, fuzz, fuzzWith, skip, test)
+import Test.Distribution
+
+
+tests : Test
+tests =
+    describe "DndCharacter"
+        [ describe "ability"
+            [ skip <|
+                fuzzWith { runs = 1000, distribution = Test.noDistribution }
+                    (Fuzz.fromGenerator DndCharacter.ability)
+                    "generated ability should be at least 3"
+                <|
+                    \ability -> Expect.atLeast 3 ability
+            , skip <|
+                fuzzWith { runs = 1000, distribution = Test.noDistribution }
+                    (Fuzz.fromGenerator DndCharacter.ability)
+                    "generated ability should be at most 18"
+                <|
+                    \ability -> Expect.atMost 18 ability
+            , skip <|
+                fuzzWith
+                    { runs = 10000
+                    , distribution =
+                        Test.expectDistribution
+                            [ ( Test.Distribution.moreThanZero, "is 3", (==) 3 ) ]
+                    }
+                    (Fuzz.fromGenerator DndCharacter.ability)
+                    "generated ability should sometimes be 3"
+                <|
+                    \_ -> Expect.pass
+            , skip <|
+                fuzzWith
+                    { runs = 1000
+                    , distribution =
+                        Test.expectDistribution
+                            [ ( Test.Distribution.moreThanZero, "is 18", (==) 18 ) ]
+                    }
+                    (Fuzz.fromGenerator DndCharacter.ability)
+                    "generated ability should sometimes be 18"
+                <|
+                    \_ -> Expect.pass
+            , skip <|
+                fuzzWith
+                    { runs = 10000
+                    , distribution =
+                        Test.expectDistribution
+                            [ ( Test.Distribution.atLeast 10, "is 13", (==) 13 )
+                            , ( Test.Distribution.atLeast 85, "is not 13", (/=) 13 )
+                            ]
+                    }
+                    (Fuzz.fromGenerator DndCharacter.ability)
+                    "13 has an approximate 13% chance of being picked"
+                <|
+                    \_ -> Expect.pass
+            ]
+        , describe "character"
+            [ skip <|
+                fuzz (Fuzz.fromGenerator DndCharacter.character)
+                    "generated character strength should be within range"
+                <|
+                    \character ->
+                        Expect.all [ Expect.atLeast 3, Expect.atMost 18 ] character.strength
+            , skip <|
+                fuzz (Fuzz.fromGenerator DndCharacter.character)
+                    "generated character dexterity should be within range"
+                <|
+                    \character ->
+                        Expect.all [ Expect.atLeast 3, Expect.atMost 18 ] character.dexterity
+            , skip <|
+                fuzz (Fuzz.fromGenerator DndCharacter.character)
+                    "generated character constitution should be within range"
+                <|
+                    \character ->
+                        Expect.all [ Expect.atLeast 3, Expect.atMost 18 ] character.constitution
+            , skip <|
+                fuzz (Fuzz.fromGenerator DndCharacter.character)
+                    "generated character intelligence should be within range"
+                <|
+                    \character ->
+                        Expect.all [ Expect.atLeast 3, Expect.atMost 18 ] character.intelligence
+            , skip <|
+                fuzz (Fuzz.fromGenerator DndCharacter.character)
+                    "generated character wisdom should be within range"
+                <|
+                    \character ->
+                        Expect.all [ Expect.atLeast 3, Expect.atMost 18 ] character.wisdom
+            , skip <|
+                fuzz (Fuzz.fromGenerator DndCharacter.character)
+                    "generated character charisma should be within range"
+                <|
+                    \character ->
+                        Expect.all [ Expect.atLeast 3, Expect.atMost 18 ] character.charisma
+            , skip <|
+                fuzz (Fuzz.fromGenerator DndCharacter.character)
+                    "generated character hitpoints should be 10 plus the constitution modifier"
+                <|
+                    \character ->
+                        Expect.equal character.hitpoints (10 + DndCharacter.modifier character.constitution)
+            , skip <|
+                fuzz (Fuzz.fromGenerator DndCharacter.character)
+                    "generated character abilities are not all equal"
+                <|
+                    \character ->
+                        let
+                            uniqueAbilities { strength, dexterity, constitution, intelligence, wisdom, charisma } =
+                                [ strength, dexterity, constitution, intelligence, wisdom, charisma ]
+                                    |> Set.fromList
+                                    |> Set.size
+                        in
+                        Expect.atLeast 2 (uniqueAbilities character)
+            , skip <|
+                fuzzWith
+                    { runs = 1000
+                    , distribution =
+                        Test.expectDistribution
+                            [ ( Test.Distribution.atLeast 40, "has low charisma", \char -> char.charisma <= 12 )
+                            , ( Test.Distribution.atLeast 40, "has high charisma", \char -> char.charisma > 12 )
+                            , ( Test.Distribution.atLeast 40, "has low strength", \char -> char.strength <= 12 )
+                            , ( Test.Distribution.atLeast 40, "has high strength", \char -> char.strength > 12 )
+                            ]
+                    }
+                    (Fuzz.fromGenerator DndCharacter.character)
+                    "generated characters are not all equal"
+                <|
+                    \_ -> Expect.pass
+            ]
+        ]

--- a/test_data/dnd-character/success/elm.json
+++ b/test_data/dnd-character/success/elm.json
@@ -1,0 +1,29 @@
+{
+    "type": "application",
+    "source-directories": [
+        "src"
+    ],
+    "elm-version": "0.19.1",
+    "dependencies": {
+        "direct": {
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
+        },
+        "indirect": {}
+    },
+    "test-dependencies": {
+        "direct": {
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
+        },
+        "indirect": {
+            "elm/bytes": "1.0.8",
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.3"
+        }
+    }
+}

--- a/test_data/dnd-character/success/expected_results.json
+++ b/test_data/dnd-character/success/expected_results.json
@@ -8,7 +8,7 @@
       "status": "pass",
       "message": null,
       "output": null,
-      "test_code": "fuzzWith {runs = 1000, distribution = Test.noDistribution}\n (Fuzz.fromGenerator DndCharacter.ability)\n \"generated ability should be at least 3\"\n \\ability -> Expect.atLeast 3 ability"
+      "test_code": "fuzzWith {runs = 1000, distribution = Test.noDistribution}\n (Fuzz.fromGenerator DndCharacter.ability)\n \"generated ability should be at least 3\"\n (\\ability -> Expect.atLeast 3 ability)"
     },
     {
       "name": "ability > generated ability should be at most 18",
@@ -16,7 +16,7 @@
       "status": "pass",
       "message": null,
       "output": null,
-      "test_code": "fuzzWith {runs = 1000, distribution = Test.noDistribution}\n (Fuzz.fromGenerator DndCharacter.ability)\n \"generated ability should be at most 18\"\n \\ability -> Expect.atMost 18 ability"
+      "test_code": "fuzzWith {runs = 1000, distribution = Test.noDistribution}\n (Fuzz.fromGenerator DndCharacter.ability)\n \"generated ability should be at most 18\"\n (\\ability -> Expect.atMost 18 ability)"
     },
     {
       "name": "ability > generated ability should sometimes be 3",
@@ -24,7 +24,7 @@
       "status": "pass",
       "message": null,
       "output": null,
-      "test_code": "fuzzWith {runs = 10000\n, distribution = Test.expectDistribution [(Test.Distribution.moreThanZero, \"is 3\", (==) 3)]}\n (Fuzz.fromGenerator DndCharacter.ability)\n \"generated ability should sometimes be 3\"\n \\_ -> Expect.pass"
+      "test_code": "fuzzWith {runs = 10000\n, distribution = Test.expectDistribution [(Test.Distribution.moreThanZero, \"is 3\", (==) 3)]}\n (Fuzz.fromGenerator DndCharacter.ability)\n \"generated ability should sometimes be 3\"\n (\\_ -> Expect.pass)"
     },
     {
       "name": "ability > generated ability should sometimes be 18",
@@ -32,7 +32,7 @@
       "status": "pass",
       "message": null,
       "output": null,
-      "test_code": "fuzzWith {runs = 1000\n, distribution = Test.expectDistribution [(Test.Distribution.moreThanZero, \"is 18\", (==) 18)]}\n (Fuzz.fromGenerator DndCharacter.ability)\n \"generated ability should sometimes be 18\"\n \\_ -> Expect.pass"
+      "test_code": "fuzzWith {runs = 1000\n, distribution = Test.expectDistribution [(Test.Distribution.moreThanZero, \"is 18\", (==) 18)]}\n (Fuzz.fromGenerator DndCharacter.ability)\n \"generated ability should sometimes be 18\"\n (\\_ -> Expect.pass)"
     },
     {
       "name": "ability > 13 has an approximate 13% chance of being picked",
@@ -40,7 +40,7 @@
       "status": "pass",
       "message": null,
       "output": null,
-      "test_code": "fuzzWith {runs = 10000\n, distribution = Test.expectDistribution [(Test.Distribution.atLeast 10, \"is 13\", (==) 13)\n, (Test.Distribution.atLeast 85, \"is not 13\", (/=) 13)]}\n (Fuzz.fromGenerator DndCharacter.ability)\n \"13 has an approximate 13% chance of being picked\"\n \\_ -> Expect.pass"
+      "test_code": "fuzzWith {runs = 10000\n, distribution = Test.expectDistribution [(Test.Distribution.atLeast 10, \"is 13\", (==) 13)\n, (Test.Distribution.atLeast 85, \"is not 13\", (/=) 13)]}\n (Fuzz.fromGenerator DndCharacter.ability)\n \"13 has an approximate 13% chance of being picked\"\n (\\_ -> Expect.pass)"
     },
     {
       "name": "character > generated character strength should be within range",
@@ -48,7 +48,7 @@
       "status": "pass",
       "message": null,
       "output": null,
-      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character strength should be within range\"\n \\character -> Expect.all [Expect.atLeast 3, Expect.atMost 18] character.strength"
+      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character strength should be within range\"\n (\\character -> Expect.all [Expect.atLeast 3, Expect.atMost 18] character.strength)"
     },
     {
       "name": "character > generated character dexterity should be within range",
@@ -56,7 +56,7 @@
       "status": "pass",
       "message": null,
       "output": null,
-      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character dexterity should be within range\"\n \\character -> Expect.all [Expect.atLeast 3, Expect.atMost 18] character.dexterity"
+      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character dexterity should be within range\"\n (\\character -> Expect.all [Expect.atLeast 3, Expect.atMost 18] character.dexterity)"
     },
     {
       "name": "character > generated character constitution should be within range",
@@ -64,7 +64,7 @@
       "status": "pass",
       "message": null,
       "output": null,
-      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character constitution should be within range\"\n \\character -> Expect.all [Expect.atLeast 3, Expect.atMost 18] character.constitution"
+      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character constitution should be within range\"\n (\\character -> Expect.all [Expect.atLeast 3, Expect.atMost 18] character.constitution)"
     },
     {
       "name": "character > generated character intelligence should be within range",
@@ -72,7 +72,7 @@
       "status": "pass",
       "message": null,
       "output": null,
-      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character intelligence should be within range\"\n \\character -> Expect.all [Expect.atLeast 3, Expect.atMost 18] character.intelligence"
+      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character intelligence should be within range\"\n (\\character -> Expect.all [Expect.atLeast 3, Expect.atMost 18] character.intelligence)"
     },
     {
       "name": "character > generated character wisdom should be within range",
@@ -80,7 +80,7 @@
       "status": "pass",
       "message": null,
       "output": null,
-      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character wisdom should be within range\"\n \\character -> Expect.all [Expect.atLeast 3, Expect.atMost 18] character.wisdom"
+      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character wisdom should be within range\"\n (\\character -> Expect.all [Expect.atLeast 3, Expect.atMost 18] character.wisdom)"
     },
     {
       "name": "character > generated character charisma should be within range",
@@ -88,7 +88,7 @@
       "status": "pass",
       "message": null,
       "output": null,
-      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character charisma should be within range\"\n \\character -> Expect.all [Expect.atLeast 3, Expect.atMost 18] character.charisma"
+      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character charisma should be within range\"\n (\\character -> Expect.all [Expect.atLeast 3, Expect.atMost 18] character.charisma)"
     },
     {
       "name": "character > generated character hitpoints should be 10 plus the constitution modifier",
@@ -96,7 +96,7 @@
       "status": "pass",
       "message": null,
       "output": null,
-      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character hitpoints should be 10 plus the constitution modifier\"\n \\character -> Expect.equal character.hitpoints (10 + DndCharacter.modifier character.constitution)"
+      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character hitpoints should be 10 plus the constitution modifier\"\n (\\character -> Expect.equal character.hitpoints (10 + DndCharacter.modifier character.constitution))"
     },
     {
       "name": "character > generated character abilities are not all equal",
@@ -104,7 +104,7 @@
       "status": "pass",
       "message": null,
       "output": null,
-      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character abilities are not all equal\"\n \\character -> let\n  \n  \n  uniqueAbilities {strength, dexterity, constitution, intelligence, wisdom, charisma} =\n      [strength, dexterity, constitution, intelligence, wisdom, charisma] |> Set.fromList |> Set.size\nin\n  Expect.atLeast 2 (uniqueAbilities character)"
+      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character abilities are not all equal\"\n (\\character -> let\n  \n  \n  uniqueAbilities {strength, dexterity, constitution, intelligence, wisdom, charisma} =\n      [strength, dexterity, constitution, intelligence, wisdom, charisma] |> Set.fromList |> Set.size\nin\n  Expect.atLeast 2 (uniqueAbilities character))"
     },
     {
       "name": "character > generated characters are not all equal",
@@ -112,7 +112,7 @@
       "status": "pass",
       "message": null,
       "output": null,
-      "test_code": "fuzzWith {runs = 1000\n, distribution = Test.expectDistribution [(Test.Distribution.atLeast 40, \"has low charisma\", \\char -> char.charisma <= 12)\n, (Test.Distribution.atLeast 40, \"has high charisma\", \\char -> char.charisma > 12)\n, (Test.Distribution.atLeast 40, \"has low strength\", \\char -> char.strength <= 12)\n, (Test.Distribution.atLeast 40, \"has high strength\", \\char -> char.strength > 12)]}\n (Fuzz.fromGenerator DndCharacter.character)\n \"generated characters are not all equal\"\n \\_ -> Expect.pass"
+      "test_code": "fuzzWith {runs = 1000\n, distribution = Test.expectDistribution [(Test.Distribution.atLeast 40, \"has low charisma\", \\char -> char.charisma <= 12)\n, (Test.Distribution.atLeast 40, \"has high charisma\", \\char -> char.charisma > 12)\n, (Test.Distribution.atLeast 40, \"has low strength\", \\char -> char.strength <= 12)\n, (Test.Distribution.atLeast 40, \"has high strength\", \\char -> char.strength > 12)]}\n (Fuzz.fromGenerator DndCharacter.character)\n \"generated characters are not all equal\"\n (\\_ -> Expect.pass)"
     }
   ]
 }

--- a/test_data/dnd-character/success/expected_results.json
+++ b/test_data/dnd-character/success/expected_results.json
@@ -1,0 +1,118 @@
+{
+  "version": 3,
+  "status": "pass",
+  "tests": [
+    {
+      "name": "ability > generated ability should be at least 3",
+      "task_id": null,
+      "status": "pass",
+      "message": null,
+      "output": null,
+      "test_code": "fuzzWith {runs = 1000, distribution = Test.noDistribution}\n (Fuzz.fromGenerator DndCharacter.ability)\n \"generated ability should be at least 3\"\n \\ability -> Expect.atLeast 3 ability"
+    },
+    {
+      "name": "ability > generated ability should be at most 18",
+      "task_id": null,
+      "status": "pass",
+      "message": null,
+      "output": null,
+      "test_code": "fuzzWith {runs = 1000, distribution = Test.noDistribution}\n (Fuzz.fromGenerator DndCharacter.ability)\n \"generated ability should be at most 18\"\n \\ability -> Expect.atMost 18 ability"
+    },
+    {
+      "name": "ability > generated ability should sometimes be 3",
+      "task_id": null,
+      "status": "pass",
+      "message": null,
+      "output": null,
+      "test_code": "fuzzWith {runs = 10000\n, distribution = Test.expectDistribution [(Test.Distribution.moreThanZero, \"is 3\", (==) 3)]}\n (Fuzz.fromGenerator DndCharacter.ability)\n \"generated ability should sometimes be 3\"\n \\_ -> Expect.pass"
+    },
+    {
+      "name": "ability > generated ability should sometimes be 18",
+      "task_id": null,
+      "status": "pass",
+      "message": null,
+      "output": null,
+      "test_code": "fuzzWith {runs = 1000\n, distribution = Test.expectDistribution [(Test.Distribution.moreThanZero, \"is 18\", (==) 18)]}\n (Fuzz.fromGenerator DndCharacter.ability)\n \"generated ability should sometimes be 18\"\n \\_ -> Expect.pass"
+    },
+    {
+      "name": "ability > 13 has an approximate 13% chance of being picked",
+      "task_id": null,
+      "status": "pass",
+      "message": null,
+      "output": null,
+      "test_code": "fuzzWith {runs = 10000\n, distribution = Test.expectDistribution [(Test.Distribution.atLeast 10, \"is 13\", (==) 13)\n, (Test.Distribution.atLeast 85, \"is not 13\", (/=) 13)]}\n (Fuzz.fromGenerator DndCharacter.ability)\n \"13 has an approximate 13% chance of being picked\"\n \\_ -> Expect.pass"
+    },
+    {
+      "name": "character > generated character strength should be within range",
+      "task_id": null,
+      "status": "pass",
+      "message": null,
+      "output": null,
+      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character strength should be within range\"\n \\character -> Expect.all [Expect.atLeast 3, Expect.atMost 18] character.strength"
+    },
+    {
+      "name": "character > generated character dexterity should be within range",
+      "task_id": null,
+      "status": "pass",
+      "message": null,
+      "output": null,
+      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character dexterity should be within range\"\n \\character -> Expect.all [Expect.atLeast 3, Expect.atMost 18] character.dexterity"
+    },
+    {
+      "name": "character > generated character constitution should be within range",
+      "task_id": null,
+      "status": "pass",
+      "message": null,
+      "output": null,
+      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character constitution should be within range\"\n \\character -> Expect.all [Expect.atLeast 3, Expect.atMost 18] character.constitution"
+    },
+    {
+      "name": "character > generated character intelligence should be within range",
+      "task_id": null,
+      "status": "pass",
+      "message": null,
+      "output": null,
+      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character intelligence should be within range\"\n \\character -> Expect.all [Expect.atLeast 3, Expect.atMost 18] character.intelligence"
+    },
+    {
+      "name": "character > generated character wisdom should be within range",
+      "task_id": null,
+      "status": "pass",
+      "message": null,
+      "output": null,
+      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character wisdom should be within range\"\n \\character -> Expect.all [Expect.atLeast 3, Expect.atMost 18] character.wisdom"
+    },
+    {
+      "name": "character > generated character charisma should be within range",
+      "task_id": null,
+      "status": "pass",
+      "message": null,
+      "output": null,
+      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character charisma should be within range\"\n \\character -> Expect.all [Expect.atLeast 3, Expect.atMost 18] character.charisma"
+    },
+    {
+      "name": "character > generated character hitpoints should be 10 plus the constitution modifier",
+      "task_id": null,
+      "status": "pass",
+      "message": null,
+      "output": null,
+      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character hitpoints should be 10 plus the constitution modifier\"\n \\character -> Expect.equal character.hitpoints (10 + DndCharacter.modifier character.constitution)"
+    },
+    {
+      "name": "character > generated character abilities are not all equal",
+      "task_id": null,
+      "status": "pass",
+      "message": null,
+      "output": null,
+      "test_code": "fuzz (Fuzz.fromGenerator DndCharacter.character)\n \"generated character abilities are not all equal\"\n \\character -> let\n  \n  \n  uniqueAbilities {strength, dexterity, constitution, intelligence, wisdom, charisma} =\n      [strength, dexterity, constitution, intelligence, wisdom, charisma] |> Set.fromList |> Set.size\nin\n  Expect.atLeast 2 (uniqueAbilities character)"
+    },
+    {
+      "name": "character > generated characters are not all equal",
+      "task_id": null,
+      "status": "pass",
+      "message": null,
+      "output": null,
+      "test_code": "fuzzWith {runs = 1000\n, distribution = Test.expectDistribution [(Test.Distribution.atLeast 40, \"has low charisma\", \\char -> char.charisma <= 12)\n, (Test.Distribution.atLeast 40, \"has high charisma\", \\char -> char.charisma > 12)\n, (Test.Distribution.atLeast 40, \"has low strength\", \\char -> char.strength <= 12)\n, (Test.Distribution.atLeast 40, \"has high strength\", \\char -> char.strength > 12)]}\n (Fuzz.fromGenerator DndCharacter.character)\n \"generated characters are not all equal\"\n \\_ -> Expect.pass"
+    }
+  ]
+}

--- a/test_data/dnd-character/success/src/DndCharacter.elm
+++ b/test_data/dnd-character/success/src/DndCharacter.elm
@@ -1,0 +1,58 @@
+module DndCharacter exposing (Character, ability, character, modifier)
+
+import Random exposing (Generator)
+
+
+type alias Character =
+    { strength : Int
+    , dexterity : Int
+    , constitution : Int
+    , intelligence : Int
+    , wisdom : Int
+    , charisma : Int
+    , hitpoints : Int
+    }
+
+
+modifier : Int -> Int
+modifier score =
+    floor ((toFloat score - 10) / 2)
+
+
+ability : Generator Int
+ability =
+    let
+        sumOfMaxThree =
+            List.sort >> List.reverse >> List.take 3 >> List.sum
+    in
+    Random.list 4 (Random.int 1 6)
+        |> Random.map sumOfMaxThree
+
+
+character : Generator Character
+character =
+    Random.constant Character
+        |> apply ability
+        |> apply ability
+        |> apply ability
+        |> apply ability
+        |> apply ability
+        |> apply ability
+        |> Random.andThen addHitpoints
+
+
+apply : Generator a -> Generator (a -> b) -> Generator b
+apply genA =
+    Random.andThen (\aToB -> Random.map aToB genA)
+
+
+addHitpoints : (Int -> Character) -> Generator Character
+addHitpoints hitpointsToCharacter =
+    let
+        dummyChar =
+            hitpointsToCharacter 0
+
+        hitpoints =
+            10 + modifier dummyChar.constitution
+    in
+    Random.constant (hitpointsToCharacter hitpoints)

--- a/test_data/dnd-character/success/tests/Tests.elm
+++ b/test_data/dnd-character/success/tests/Tests.elm
@@ -1,0 +1,134 @@
+module Tests exposing (tests)
+
+import DndCharacter
+import Expect
+import Fuzz
+import Set
+import Test exposing (Test, describe, fuzz, fuzzWith, skip, test)
+import Test.Distribution
+
+
+tests : Test
+tests =
+    describe "DndCharacter"
+        [ describe "ability"
+            [ skip <|
+                fuzzWith { runs = 1000, distribution = Test.noDistribution }
+                    (Fuzz.fromGenerator DndCharacter.ability)
+                    "generated ability should be at least 3"
+                <|
+                    \ability -> Expect.atLeast 3 ability
+            , skip <|
+                fuzzWith { runs = 1000, distribution = Test.noDistribution }
+                    (Fuzz.fromGenerator DndCharacter.ability)
+                    "generated ability should be at most 18"
+                <|
+                    \ability -> Expect.atMost 18 ability
+            , skip <|
+                fuzzWith
+                    { runs = 10000
+                    , distribution =
+                        Test.expectDistribution
+                            [ ( Test.Distribution.moreThanZero, "is 3", (==) 3 ) ]
+                    }
+                    (Fuzz.fromGenerator DndCharacter.ability)
+                    "generated ability should sometimes be 3"
+                <|
+                    \_ -> Expect.pass
+            , skip <|
+                fuzzWith
+                    { runs = 1000
+                    , distribution =
+                        Test.expectDistribution
+                            [ ( Test.Distribution.moreThanZero, "is 18", (==) 18 ) ]
+                    }
+                    (Fuzz.fromGenerator DndCharacter.ability)
+                    "generated ability should sometimes be 18"
+                <|
+                    \_ -> Expect.pass
+            , skip <|
+                fuzzWith
+                    { runs = 10000
+                    , distribution =
+                        Test.expectDistribution
+                            [ ( Test.Distribution.atLeast 10, "is 13", (==) 13 )
+                            , ( Test.Distribution.atLeast 85, "is not 13", (/=) 13 )
+                            ]
+                    }
+                    (Fuzz.fromGenerator DndCharacter.ability)
+                    "13 has an approximate 13% chance of being picked"
+                <|
+                    \_ -> Expect.pass
+            ]
+        , describe "character"
+            [ skip <|
+                fuzz (Fuzz.fromGenerator DndCharacter.character)
+                    "generated character strength should be within range"
+                <|
+                    \character ->
+                        Expect.all [ Expect.atLeast 3, Expect.atMost 18 ] character.strength
+            , skip <|
+                fuzz (Fuzz.fromGenerator DndCharacter.character)
+                    "generated character dexterity should be within range"
+                <|
+                    \character ->
+                        Expect.all [ Expect.atLeast 3, Expect.atMost 18 ] character.dexterity
+            , skip <|
+                fuzz (Fuzz.fromGenerator DndCharacter.character)
+                    "generated character constitution should be within range"
+                <|
+                    \character ->
+                        Expect.all [ Expect.atLeast 3, Expect.atMost 18 ] character.constitution
+            , skip <|
+                fuzz (Fuzz.fromGenerator DndCharacter.character)
+                    "generated character intelligence should be within range"
+                <|
+                    \character ->
+                        Expect.all [ Expect.atLeast 3, Expect.atMost 18 ] character.intelligence
+            , skip <|
+                fuzz (Fuzz.fromGenerator DndCharacter.character)
+                    "generated character wisdom should be within range"
+                <|
+                    \character ->
+                        Expect.all [ Expect.atLeast 3, Expect.atMost 18 ] character.wisdom
+            , skip <|
+                fuzz (Fuzz.fromGenerator DndCharacter.character)
+                    "generated character charisma should be within range"
+                <|
+                    \character ->
+                        Expect.all [ Expect.atLeast 3, Expect.atMost 18 ] character.charisma
+            , skip <|
+                fuzz (Fuzz.fromGenerator DndCharacter.character)
+                    "generated character hitpoints should be 10 plus the constitution modifier"
+                <|
+                    \character ->
+                        Expect.equal character.hitpoints (10 + DndCharacter.modifier character.constitution)
+            , skip <|
+                fuzz (Fuzz.fromGenerator DndCharacter.character)
+                    "generated character abilities are not all equal"
+                <|
+                    \character ->
+                        let
+                            uniqueAbilities { strength, dexterity, constitution, intelligence, wisdom, charisma } =
+                                [ strength, dexterity, constitution, intelligence, wisdom, charisma ]
+                                    |> Set.fromList
+                                    |> Set.size
+                        in
+                        Expect.atLeast 2 (uniqueAbilities character)
+            , skip <|
+                fuzzWith
+                    { runs = 1000
+                    , distribution =
+                        Test.expectDistribution
+                            [ ( Test.Distribution.atLeast 40, "has low charisma", \char -> char.charisma <= 12 )
+                            , ( Test.Distribution.atLeast 40, "has high charisma", \char -> char.charisma > 12 )
+                            , ( Test.Distribution.atLeast 40, "has low strength", \char -> char.strength <= 12 )
+                            , ( Test.Distribution.atLeast 40, "has high strength", \char -> char.strength > 12 )
+                            ]
+                    }
+                    (Fuzz.fromGenerator DndCharacter.character)
+                    "generated characters are not all equal"
+                <|
+                    \_ -> Expect.pass
+            ]
+        ]


### PR DESCRIPTION
This is the sister PR to [this one](https://github.com/exercism/elm/pull/549), where I'm trying to to use `fuzz` for the first time.

This PR makes it possible for the test runner to parse `fuzz`, `fuzz2`, `fuzz3` and `fuzzWith`. For example, given the test
```elm
            , skip <|
                fuzzWith
                    { runs = 1000
                    , distribution =
                        Test.expectDistribution
                            [ ( Test.Distribution.atLeast 40, "has low charisma", \char -> char.charisma <= 12 )
                            , ( Test.Distribution.atLeast 40, "has high charisma", \char -> char.charisma > 12 )
                            , ( Test.Distribution.atLeast 40, "has low strength", \char -> char.strength <= 12 )
                            , ( Test.Distribution.atLeast 40, "has high strength", \char -> char.strength > 12 )
                            ]
                    }
                    (Fuzz.fromGenerator DndCharacter.character)
                    "generated characters are not all equal"
                <|
                    \_ -> Expect.pass
```

Will be parsed and shown to the students as

```elm
fuzzWith {runs = 1000
, distribution = Test.expectDistribution [(Test.Distribution.atLeast 40, "has low charisma", \char -> char.charisma <= 12)
, (Test.Distribution.atLeast 40, "has high charisma", \char -> char.charisma > 12)
, (Test.Distribution.atLeast 40, "has low strength", \char -> char.strength <= 12)
, (Test.Distribution.atLeast 40, "has high strength", \char -> char.strength > 12)]}
 (Fuzz.fromGenerator DndCharacter.character)
 "generated characters are not all equal"
 (\_ -> Expect.pass)
```

Note that for normal tests we only show the inside of the lambda, but for fuzz tests we need to show the full thing, because the arguments are required to understand the test (otherwise this example would only render `Expect.pass`).

For a wrong solution, the error message the student will see is
```
    Distribution of label "has high charisma" was insufficient:
      expected:  40.000%
      got:       0.000%.
    
    (Generated 1000 values.)
```

Note that the diagrams don't appear in this version of the messages.