### PR TITLE
CI: pin GitHub Actions runners

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -2,7 +2,7 @@ name: Check the Docker image on PR
 on: pull_request
 jobs:
   build-docker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
@@ -28,7 +28,7 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache
 
   smoke-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
@@ -37,7 +37,7 @@ jobs:
         run: bin/run-tests-in-docker.sh
 
   test-all-exercises:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout elm-test-runner
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c


### PR DESCRIPTION
This PR updates GitHub Actions runners to a specific version.
This ensures that the workflow will always run on the same runner, which makes your build _stable_.

The PR updates the *-latest version with the current version, as specified in https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources.

See https://exercism.org/docs/building/github/gha-best-practices#h-pin-test-runners-to-version for more information.