### PR TITLE
Pin the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine AS builder
+FROM node:24.15.0-alpine3.23@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f AS builder
 
 # Working directory as specified by exercism
 WORKDIR /opt/test-runner
@@ -44,7 +44,7 @@ COPY bin/run.sh bin/run.sh
 COPY bin/smoke_test.sh bin/smoke_test.sh
 
 # Lightweight runner container
-FROM node:lts-alpine
+FROM node:24.15.0-alpine3.23@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f
 WORKDIR /opt/test-runner
 ENV PATH="/opt/test-runner/bin:${PATH}"
 COPY --from=builder /opt/test-runner/bin bin


### PR DESCRIPTION
Exercism's policy is to prefer pinned versions.
Using the same hash across all runners allows us to store and reuse the same image, rather than needing to store a per-runner base image. This helps cut down on storage costs.